### PR TITLE
Improves renderError prop signature

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 6414,
-    "minified": 2934,
-    "gzipped": 1305,
+    "bundled": 6442,
+    "minified": 2948,
+    "gzipped": 1311,
     "treeshaked": {
       "rollup": {
         "code": 1635,
@@ -14,8 +14,8 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 7663,
-    "minified": 3719,
-    "gzipped": 1418
+    "bundled": 7697,
+    "minified": 3733,
+    "gzipped": 1424
   }
 }

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const Tweets = ({ userId }) => {
 const UserProfile = ({ userId }) => (
   <RemoteResourceBoundary
     fallback={<p>Loading...</p>}
-    renderError={(error, retry) => (
+    renderError={({ error, retry }) => (
       <div>
         <p>{error}</p>
         <button onClick={retry}>Retry</button>
@@ -244,10 +244,10 @@ const UserProfile = ({ userId }) => (
     /* Optional: A callback that is invoked when any thrown promise rejects */
     onLoadError={logError}
     /* A render prop that receives the error and a function to clear the error, which allows the children to re-render and attempt loading again */
-    renderError={(error, clearError) => (
+    renderError={({ error, retry }) => (
       <div>
         <p>{error}</p>
-        <button onClick={clearError}>Try again</button>
+        <button onClick={retry}>Try again</button>
       </div>
     )}
   >

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -188,7 +188,10 @@ var RemoteResourceBoundary = function RemoteResourceBoundary(_ref) {
   return React__default.createElement(Context.Provider, {
     value: providerValue
   }, error.map(function (err) {
-    return renderError(err, clearError);
+    return renderError({
+      error: err,
+      retry: clearError
+    });
   }).getOrElse(React__default.createElement(React.Suspense, {
     fallback: fallback
   }, children)));

--- a/dist/index.js
+++ b/dist/index.js
@@ -163,7 +163,10 @@ const RemoteResourceBoundary = (_ref) => {
   }, []);
   return React.createElement(Context.Provider, {
     value: providerValue
-  }, error.map(err => renderError(err, clearError)).getOrElse(React.createElement(Suspense, {
+  }, error.map(err => renderError({
+    error: err,
+    retry: clearError
+  })).getOrElse(React.createElement(Suspense, {
     fallback: fallback
   }, children)));
 };

--- a/src/RemoteResourceBoundary.js
+++ b/src/RemoteResourceBoundary.js
@@ -26,7 +26,7 @@ const RemoteResourceBoundary = ({
   return (
     <Context.Provider value={providerValue}>
       {error
-        .map(err => renderError(err, clearError))
+        .map(err => renderError({ error: err, retry: clearError }))
         .getOrElse(<Suspense fallback={fallback}>{children}</Suspense>)}
     </Context.Provider>
   );

--- a/src/RemoteResourceBoundary.test.js
+++ b/src/RemoteResourceBoundary.test.js
@@ -47,7 +47,7 @@ describe("RemoteResourceBoundary", () => {
     const { getByText } = render(
       <RemoteResourceBoundary
         fallback={<p>Loading...</p>}
-        renderError={rejected => <p>{rejected}</p>}
+        renderError={({ error }) => <p>{error}</p>}
       >
         <MockResourceConsumer resource={resource} />
       </RemoteResourceBoundary>
@@ -69,7 +69,7 @@ describe("RemoteResourceBoundary", () => {
     const { getByText } = render(
       <RemoteResourceBoundary
         fallback={<p>Loading...</p>}
-        renderError={rejected => <p>{rejected}</p>}
+        renderError={({ error }) => <p>{error}</p>}
         onLoadError={spy}
       >
         <MockResourceConsumer resource={resource} />
@@ -100,9 +100,9 @@ describe("RemoteResourceBoundary", () => {
     const { getByText } = render(
       <RemoteResourceBoundary
         fallback={<p>Loading...</p>}
-        renderError={(rejected, retry) => (
+        renderError={({ error, retry }) => (
           <p>
-            {rejected}
+            {error}
             <button onClick={retry}>retry</button>
           </p>
         )}


### PR DESCRIPTION
BREAKING CHANGE: The arguments that renderError should expect has
changed to be an object with `error` and `retry` props. This allows one
to pass a React component in first class.