### PR TITLE
fix: exports persistResource

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 6442,
-    "minified": 2948,
-    "gzipped": 1311,
+    "bundled": 7041,
+    "minified": 3207,
+    "gzipped": 1385,
     "treeshaked": {
       "rollup": {
         "code": 1635,
@@ -14,8 +14,8 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 7697,
-    "minified": 3733,
-    "gzipped": 1424
+    "bundled": 8407,
+    "minified": 4054,
+    "gzipped": 1505
   }
 }

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -163,6 +163,31 @@ var createSingleEntryResource = function createSingleEntryResource(loader, entri
   }, loader, entriesExpireAfter);
 };
 
+var persistResource = function persistResource(getInitialState, persistState, resource) {
+  var loader = null;
+  return _extends({}, resource, {
+    useEntry: function useEntry() {
+      var resourceState = resource.getState();
+
+      if (resourceState === undefined) {
+        loader = getInitialState().then(resource.setState).then(function () {
+          return resource.subscribe(function () {
+            persistState(resource.getState());
+          });
+        })["finally"](function () {
+          loader = null;
+        });
+      }
+
+      if (loader) {
+        throw loader;
+      }
+
+      return resource.useEntry.apply(resource, arguments);
+    }
+  });
+};
+
 var RemoteResourceBoundary = function RemoteResourceBoundary(_ref) {
   var children = _ref.children,
       _ref$onLoadError = _ref.onLoadError,
@@ -255,5 +280,6 @@ exports.RemoteResourceBoundary = RemoteResourceBoundary;
 exports.createKeyedResource = createKeyedResource;
 exports.createResource = createResource;
 exports.createSingleEntryResource = createSingleEntryResource;
+exports.persistResource = persistResource;
 exports.useAutoSave = useAutoSave;
 exports.useSuspense = useSuspense;

--- a/dist/index.js
+++ b/dist/index.js
@@ -141,6 +141,29 @@ const createKeyedResource = curryN(2, (createKey, loader, entriesExpireAfter) =>
 
 const createSingleEntryResource = (loader, entriesExpireAfter) => createResource(resourceState => resourceState, (resourceState, args, data) => data, loader, entriesExpireAfter);
 
+const persistResource = (getInitialState, persistState, resource) => {
+  let loader = null;
+  return _extends({}, resource, {
+    useEntry: function useEntry() {
+      const resourceState = resource.getState();
+
+      if (resourceState === undefined) {
+        loader = getInitialState().then(resource.setState).then(() => resource.subscribe(() => {
+          persistState(resource.getState());
+        })).finally(() => {
+          loader = null;
+        });
+      }
+
+      if (loader) {
+        throw loader;
+      }
+
+      return resource.useEntry(...arguments);
+    }
+  });
+};
+
 const RemoteResourceBoundary = (_ref) => {
   let children = _ref.children,
       _ref$onLoadError = _ref.onLoadError,
@@ -217,4 +240,4 @@ const useSuspense = fn => {
   }));
 };
 
-export { RemoteResourceBoundary, createKeyedResource, createResource, createSingleEntryResource, useAutoSave, useSuspense };
+export { RemoteResourceBoundary, createKeyedResource, createResource, createSingleEntryResource, persistResource, useAutoSave, useSuspense };

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export { default as createResource } from "./create-resource";
 export {
   default as createSingleEntryResource
 } from "./create-single-entry-resource";
+export { default as persistResource } from "./persist-resource";
 export { default as RemoteResourceBoundary } from "./RemoteResourceBoundary";
 export { default as useAutoSave } from "./use-auto-save";
 export { default as useSuspense } from "./use-suspense";


### PR DESCRIPTION
`persistResource` is missing in exports. This PR adds `persistResource` as an export. 