### PR TITLE
Adds provideContext function

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/index.js": {
-    "bundled": 8199,
-    "minified": 3904,
-    "gzipped": 1531,
+    "bundled": 8540,
+    "minified": 4096,
+    "gzipped": 1585,
     "treeshaked": {
       "rollup": {
-        "code": 586,
-        "import_statements": 218
+        "code": 754,
+        "import_statements": 241
       },
       "webpack": {
-        "code": 1829
+        "code": 2005
       }
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 9878,
-    "minified": 4902,
-    "gzipped": 1678
+    "bundled": 10308,
+    "minified": 5157,
+    "gzipped": 1744
   }
 }

--- a/README.md
+++ b/README.md
@@ -408,6 +408,41 @@ const ProfileForm = () => {
 };
 ```
 
+### `provideContext`
+
+A function that allows you to use a React hook to provide a value to a resource.
+
+```javascript
+const authTokenResource = createSimpleResource(() =>
+  Promise.resolve(localStorage.getItem("authToken") || "")
+);
+
+const useAuthToken = () => {
+  const [authToken] = authTokenResource.useState();
+  return authToken;
+};
+
+const profileResource = provideContext(
+  useAuthToken,
+  createSimpleResource(authToken =>
+    fetch("/my_profile", {
+      headers: {
+        Authorization: `Bearer ${authToken}`
+      }
+    }).then(res => res.json())
+  )
+);
+
+const ProfileForm = () => {
+  const [profile] = profileResource.useState();
+  return (
+    // ...
+  );
+};
+```
+
+&nbsp;
+
 &nbsp;
 
 ### `useAutoSave`

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -239,6 +239,18 @@ var persistResource = function persistResource(getInitialState, persistState, re
   });
 };
 
+var provideContext = ramda.curry(function (provider, resource) {
+  return _extends({}, resource, {
+    useState: function useState() {
+      for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      return resource.useState.apply(resource, [provider.apply(void 0, args)].concat(args));
+    }
+  });
+});
+
 var RemoteResourceBoundary = function RemoteResourceBoundary(_ref) {
   var children = _ref.children,
       _ref$onLoadError = _ref.onLoadError,
@@ -345,6 +357,7 @@ exports.createKeyedResource = createKeyedResource;
 exports.createResource = createResource;
 exports.createSimpleResource = createSimpleResource;
 exports.persistResource = persistResource;
+exports.provideContext = provideContext;
 exports.resetAllResources = resetAllResources;
 exports.resetResources = resetResources;
 exports.useAutoSave = useAutoSave;

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,7 +4,7 @@ import React, { createContext, useRef, useState, useContext, useEffect, useCallb
 import uuid from 'uuid/v1';
 import { createStore } from 'redux';
 import { Map as Map$1 } from 'immutable';
-import { equals } from 'ramda';
+import { equals, curry } from 'ramda';
 import Maybe from 'data.maybe';
 
 const RECEIVE_STATE = "RECEIVE_STATE";
@@ -211,6 +211,16 @@ const persistResource = (getInitialState, persistState, resource) => {
   });
 };
 
+const provideContext = curry((provider, resource) => _extends({}, resource, {
+  useState: function useState() {
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    return resource.useState(provider(...args), ...args);
+  }
+}));
+
 const RemoteResourceBoundary = (_ref) => {
   let children = _ref.children,
       _ref$onLoadError = _ref.onLoadError,
@@ -296,4 +306,4 @@ const useSuspense = fn => {
   }));
 };
 
-export { RemoteResourceBoundary, createKeyedResource, createResource, createSimpleResource, persistResource, resetAllResources, resetResources, useAutoSave, useSuspense };
+export { RemoteResourceBoundary, createKeyedResource, createResource, createSimpleResource, persistResource, provideContext, resetAllResources, resetResources, useAutoSave, useSuspense };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ export { default as createKeyedResource } from "./create-keyed-resource";
 export { default as createResource } from "./create-resource";
 export { default as createSimpleResource } from "./create-simple-resource";
 export { default as persistResource } from "./persist-resource";
+export { default as provideContext } from "./provide-context";
 export { default as RemoteResourceBoundary } from "./RemoteResourceBoundary";
 export { default as resetAllResources } from "./reset-all-resources";
 export { default as resetResources } from "./reset-resources";

--- a/src/provide-context.js
+++ b/src/provide-context.js
@@ -1,0 +1,8 @@
+import { curry } from "ramda";
+
+const provideContext = curry((provider, resource) => ({
+  ...resource,
+  useState: (...args) => resource.useState(provider(...args), ...args)
+}));
+
+export default provideContext;

--- a/src/provide-context.test.js
+++ b/src/provide-context.test.js
@@ -1,0 +1,150 @@
+import * as React from "react";
+import provideContext from "./provide-context";
+import createResource from "./create-resource";
+import createSimpleResource from "./create-simple-resource";
+import { assertResourceShape } from "./__mocks__/assert-resource-shape";
+import { render, waitForElement } from "react-testing-library";
+
+describe("provideContext", () => {
+  it("is a curried function with an arity of two", () => {
+    expect(typeof provideContext).toBe("function");
+    expect(provideContext.length).toBe(2);
+
+    const result = provideContext(x => x);
+    expect(typeof result).toBe("function");
+    expect(result.length).toBe(1);
+  });
+
+  it("creates a resource", () => {
+    assertResourceShape(
+      provideContext(
+        x => x,
+        createSimpleResource(() => Promise.resolve("resolved"))
+      )
+    );
+  });
+
+  it("provides the return value of the provider to the selectState function", () => {
+    const value = "abc123";
+    const selectState = jest
+      .fn()
+      .mockImplementation((state, [authToken]) => state);
+    const resource = provideContext(
+      () => value,
+      createResource({
+        selectState,
+        setState: (_, __, value) => value,
+        loader: authToken => Promise.resolve(authToken)
+      })
+    );
+
+    const Example = () => {
+      const [state] = resource.useState();
+      return state;
+    };
+
+    render(
+      <React.Suspense fallback={null}>
+        <Example />
+      </React.Suspense>
+    );
+
+    expect(selectState).toHaveBeenCalledWith(undefined, [value]);
+  });
+
+  it("provides the return value of the provider to the setState function", async () => {
+    const value = "abc123";
+    const setState = jest.fn().mockImplementation((_, __, value) => value);
+    const resource = provideContext(
+      () => value,
+      createResource({
+        selectState: state => state,
+        setState,
+        loader: authToken => Promise.resolve(authToken)
+      })
+    );
+
+    const Example = () => {
+      const [state] = resource.useState();
+      return state;
+    };
+
+    const { getByText } = render(
+      <React.Suspense fallback={null}>
+        <Example />
+      </React.Suspense>
+    );
+
+    await waitForElement(() => getByText(value));
+
+    expect(setState).toHaveBeenCalledWith(undefined, [value], value);
+  });
+
+  it("provides the return value of the provider to the loader function", () => {
+    const value = "abc123";
+    const loader = jest
+      .fn()
+      .mockImplementation(authToken => Promise.resolve(authToken));
+    const resource = provideContext(() => value, createSimpleResource(loader));
+
+    const Example = () => {
+      const [state] = resource.useState();
+      return state;
+    };
+
+    render(
+      <React.Suspense fallback={null}>
+        <Example />
+      </React.Suspense>
+    );
+
+    expect(loader).toHaveBeenCalledWith(value);
+  });
+
+  it("passes the arguments to useState to the provider and the loader", () => {
+    const loader = jest
+      .fn()
+      .mockImplementation(authToken => Promise.resolve(authToken));
+    const resource = provideContext(
+      (x, y) => `${x}${y}`,
+      createSimpleResource(loader)
+    );
+
+    const Example = () => {
+      const [state] = resource.useState("abc", "123");
+      return state;
+    };
+
+    render(
+      <React.Suspense fallback={null}>
+        <Example />
+      </React.Suspense>
+    );
+
+    expect(loader).toHaveBeenCalledWith("abc123", "abc", "123");
+  });
+
+  it("can use a react hook to provide a value to the loader function", async () => {
+    const AuthTokenContext = React.createContext("");
+    const useAuthToken = () => React.useContext(AuthTokenContext);
+    const loader = jest
+      .fn()
+      .mockImplementation(authToken => Promise.resolve(authToken));
+    const resource = provideContext(useAuthToken, createSimpleResource(loader));
+
+    const Example = () => {
+      const [state] = resource.useState();
+      return state;
+    };
+
+    render(
+      <AuthTokenContext.Provider value="abc123">
+        <React.Suspense fallback={null}>
+          <Example />
+        </React.Suspense>
+      </AuthTokenContext.Provider>
+    );
+
+    expect(loader).toHaveBeenCalledWith("abc123");
+  });
+});

--- a/src/provide-context.test.js
+++ b/src/provide-context.test.js
@@ -147,4 +147,41 @@ describe("provideContext", () => {
 
     expect(loader).toHaveBeenCalledWith("abc123");
   });
+
+  it("can compose provideContexts", () => {
+    const AuthTokenContext = React.createContext("");
+    const CurrentSystemIdContext = React.createContext("");
+
+    const provideAuthToken = provideContext(() =>
+      React.useContext(AuthTokenContext)
+    );
+    const provideCurrentSystemId = provideContext(() =>
+      React.useContext(CurrentSystemIdContext)
+    );
+
+    const loader = jest
+      .fn()
+      .mockImplementation((authToken, systemId) => Promise.resolve(authToken));
+
+    const resource = provideCurrentSystemId(
+      provideAuthToken(createSimpleResource(loader))
+    );
+
+    const Example = () => {
+      const [state] = resource.useState();
+      return state;
+    };
+
+    render(
+      <AuthTokenContext.Provider value="abc123">
+        <CurrentSystemIdContext.Provider value={12345}>
+          <React.Suspense fallback={null}>
+            <Example />
+          </React.Suspense>
+        </CurrentSystemIdContext.Provider>
+      </AuthTokenContext.Provider>
+    );
+
+    expect(loader).toHaveBeenCalledWith("abc123", 12345);
+  });
 });


### PR DESCRIPTION
Adds `provideContext` function: a mechanism for providing data using React hooks. It enhances a normal resource by running the given hook when using `enhancedResource.useState` and passing the return value into the given resource's `useState` hook.

Have some data in React Context? Pass in `() => useContext(YourImportantContext)`.

Need to use the state from another resource? Pass in a custom hook that returns the resource state.

```javascript
const authTokenResource = createSimpleResource(() =>
  Promise.resolve(localStorage.getItem("authToken") || "")
);

const useAuthToken = () => {
  const [authToken] = authTokenResource.useState();
  return authToken;
};

const profileResource = provideContext(
  useAuthToken,
  createSimpleResource(authToken =>
    fetch("/my_profile", {
      headers: {
        Authorization: `Bearer ${authToken}`
      }
    }).then(res => res.json())
  )
);

const ProfileForm = () => {
  const [profile] = profileResource.useState();
  return (
    // ...
  );
};
```

The biggest thing I'm curious to hear feedback on is if we should make it to where you can provide multiple values.

Maybe something like this:

```javascript
const userCodesResource = provideContext(
  useAuthToken,
  useCurrentSystemId,
  createKeyedResource(
    (authToken, systemId) => fetch(`/v2/panels/${systemId}/user_codes?auth_token=${authToken}`)
  )
);
```

or

```javascript
const userCodesResource = provideContext(
  [useAuthToken, useCurrentSystemId],
  createKeyedResource(
    (authToken, systemId) => fetch(`/v2/panels/${systemId}/user_codes?auth_token=${authToken}`)
  )
);
```